### PR TITLE
docs: update management API endpoints to use ServiceToken authentication

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8125,6 +8125,12 @@ paths:
         - url: https://api.suprsend.com
       security:
         - ServiceTokenAuth: []
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X GET "https://api.suprsend.com/v1/{workspace}/workflow/" \
+              --header 'Authorization: ServiceToken <token>' \
+              --header 'Content-Type: application/json'
       parameters:
         - in: path
           name: workspace
@@ -8236,6 +8242,12 @@ paths:
         - url: https://api.suprsend.com
       security:
         - ServiceTokenAuth: []
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X GET "https://api.suprsend.com/v1/{workspace}/workflow/{slug}/" \
+              --header 'Authorization: ServiceToken <token>' \
+              --header 'Content-Type: application/json'
       parameters:
         - in: path
           name: workspace
@@ -8320,6 +8332,31 @@ paths:
         - url: https://api.suprsend.com
       security:
         - ServiceTokenAuth: []
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST "https://api.suprsend.com/v1/{workspace}/workflow/{slug}/" \
+              --header 'Authorization: ServiceToken <token>' \
+              --header 'Content-Type: application/json' \
+              --data '{
+                "name": "Welcome Email",
+                "description": "Sends welcome email to new users",
+                "category": "transactional",
+                "tags": ["welcome", "onboarding"],
+                "tree": {
+                  "nodes": [
+                    {
+                      "name": "Send Email",
+                      "node_type": "send_email",
+                      "properties": {
+                        "template": "welcome-email-template",
+                        "subject": "Welcome to our platform!"
+                      },
+                      "description": "Send welcome email to new users"
+                    }
+                  ]
+                }
+              }'
       parameters:
         - in: path
           name: workspace
@@ -8399,6 +8436,12 @@ paths:
         - url: https://api.suprsend.com
       security:
         - ServiceTokenAuth: []
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X DELETE "https://api.suprsend.com/v1/{workspace}/workflow/{slug}/" \
+              --header 'Authorization: ServiceToken <token>' \
+              --header 'Content-Type: application/json'
       parameters:
         - in: path
           name: workspace
@@ -8433,6 +8476,12 @@ paths:
         - url: https://api.suprsend.com
       security:
         - ServiceTokenAuth: []
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X PATCH "https://api.suprsend.com/v1/{workspace}/workflow/{slug}/commit/" \
+              --header 'Authorization: ServiceToken <token>' \
+              --header 'Content-Type: application/json'
       parameters:
         - in: path
           name: workspace
@@ -8476,6 +8525,15 @@ paths:
         - url: https://api.suprsend.com
       security:
         - ServiceTokenAuth: []
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X PATCH "https://api.suprsend.com/v1/{workspace}/workflow/{slug}/enable/" \
+              --header 'Authorization: ServiceToken <token>' \
+              --header 'Content-Type: application/json' \
+              --data '{
+                "is_enabled": true
+              }'
       parameters:
         - in: path
           name: workspace


### PR DESCRIPTION
-  Add x-codeSamples to all (management APIs) workflow-related endpoints in openapi.yaml
- Change authentication header from 'Bearer <token>' to 'ServiceToken <token>'
- Update curl examples for:
  - List Workflows (GET /v1/{workspace}/workflow/)
  - Get Workflow Details (GET /v1/{workspace}/workflow/{slug}/)
  - Create/Update Workflow (POST /v1/{workspace}/workflow/{slug}/)
  - Delete Workflow (DELETE /v1/{workspace}/workflow/{slug}/)
  - Commit Workflow (PATCH /v1/{workspace}/workflow/{slug}/commit/)
  - Enable/Disable Workflow (PATCH /v1/{workspace}/workflow/{slug}/enable/)