### PR TITLE
Docs: Add SDK-to-API context line and link Quickstarts to API Reference

### DIFF
--- a/docs/email-quick-start.mdx
+++ b/docs/email-quick-start.mdx
@@ -253,6 +253,11 @@ description: "Set up guide to send Email notifications via SuprSend."
   </Step>
   <Step title="Check logs to see the status of your sent notification" stepNumber="5">
     Once triggered, you can monitor the request and it's status on the "Requests" tab, and view step-by-step debugging of each execution on the `Execution` tab inside workflow.
+    
+    **Related API References:**
+    - [Trigger Workflow API](/reference/trigger-workflow-api) - Direct API trigger
+    - [Create/Update Users API](/reference/create-update-users) - User management
+    - [Trigger Event API](/reference/trigger-event) - Event-based triggers
   </Step>
   <Step title="Test with your Email vendor" stepNumber="6">
     You have to bring your own vendor to setup email notification in staging and production workspaces. However, you can test your workflows in Sandbox where sample vendors are pre-added. You can clone workflows from one workspace to another. All you have to do is fill in the vendor form for your [respective vendor](/docs/email-vendor-integration) and you are good to go.

--- a/docs/flutter-android-integration.mdx
+++ b/docs/flutter-android-integration.mdx
@@ -3,6 +3,8 @@ title: "Android Integration"
 description: "This document will cover integration steps for Android side of your Flutter application."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 <Steps>

--- a/docs/flutter-ios-integration.mdx
+++ b/docs/flutter-ios-integration.mdx
@@ -3,6 +3,8 @@ title: "iOS Integration"
 description: "This document will cover integration steps for iOS side of your Flutter application."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 <Steps>

--- a/docs/inbox-quick-start.mdx
+++ b/docs/inbox-quick-start.mdx
@@ -273,6 +273,11 @@ description: "Set up guide to send In-app Inbox notifications via SuprSend."
 
   <Step title="Check logs to see the status of your sent notification">
     Once triggered, you can monitor the request and it's status on the "Requests" tab, and view step-by-step debugging of each execution on the "Execution" tab inside workflow.
+    
+    **Related API References:**
+    - [Trigger Workflow API](/reference/trigger-workflow-api) - Direct API trigger
+    - [Create/Update Users API](/reference/create-update-users) - User management
+    - [Trigger Event API](/reference/trigger-event) - Event-based triggers
   </Step>
 
   <Step title="Integrate Inbox in your product">

--- a/docs/integrate-android-sdk.mdx
+++ b/docs/integrate-android-sdk.mdx
@@ -3,6 +3,8 @@ title: "Integrate Android SDK"
 description: "SDK Integration steps to enable AndroidPush notification in your native android app."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 <Steps>

--- a/docs/integrate-go-sdk.mdx
+++ b/docs/integrate-go-sdk.mdx
@@ -3,6 +3,8 @@ title: "Integrate Go SDK"
 description: "Install & Initialize SuprSend Go SDK using your workspace credentials for sending notifications."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 Install `suprsend-go` sdk

--- a/docs/integrate-java-sdk.mdx
+++ b/docs/integrate-java-sdk.mdx
@@ -3,6 +3,8 @@ title: "Integrate Java SDK"
 description: "Install & Initialize SuprSend Java SDK using your workspace credentials for sending notifications."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 For SDK installation, you'll have to add the SuprSend jar file. You can include the jar using following two ways:

--- a/docs/integrate-javascript-sdk.mdx
+++ b/docs/integrate-javascript-sdk.mdx
@@ -3,6 +3,8 @@ title: "Integrate Javascript SDK"
 description: "Web SDK Integration to enable WebPush, Preferences, & In-app feed in javascript websites like React, Vue, and Next.js."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 <Info>
   📘 **Upgrading major version of SDK:**
 

--- a/docs/integrate-node-sdk.mdx
+++ b/docs/integrate-node-sdk.mdx
@@ -3,6 +3,8 @@ title: "Integrate Node SDK"
 description: "Install & Initialize SuprSend NodeJS SDK using your workspace credentials for sending notifications."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 <CodeGroup>

--- a/docs/integrate-python-sdk.mdx
+++ b/docs/integrate-python-sdk.mdx
@@ -3,6 +3,8 @@ title: "Integrate Python SDK"
 description: "Install & Initialize SuprSend Python SDK using your workspace credentials for sending notifications."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 <Steps>

--- a/docs/ios-integration.mdx
+++ b/docs/ios-integration.mdx
@@ -3,6 +3,8 @@ title: "Integration"
 description: "Integrate SuprSend SDK in your Swift project"
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 <Warning>
  **`SuprSendSdk` is deprecated. Please migrate to `SuprSend` SDK**
 

--- a/docs/mobile-push-quick-start.mdx
+++ b/docs/mobile-push-quick-start.mdx
@@ -333,6 +333,11 @@ description: "Quickly set up & send Mobile Push notifications using SuprSend SDK
   </Step>
   <Step title="Check logs to see the status of your sent notification">
     Once triggered, you can monitor the request and it's status on the '`Requests`' tab, and view step-by-step debugging of each execution on the '`Execution`'' tab inside workflow.
+    
+    **Related API References:**
+    - [Trigger Workflow API](/reference/trigger-workflow-api) - Direct API trigger
+    - [Create/Update Users API](/reference/create-update-users) - User management
+    - [Trigger Event API](/reference/trigger-event) - Event-based triggers
   </Step>
   <Step title="Push to Production">
     In SuprSend, each environment is isolated, meaning workflows, users, and vendors are configured separately in testing and production workspaces.

--- a/docs/ms-teams-quick-start.mdx
+++ b/docs/ms-teams-quick-start.mdx
@@ -273,6 +273,11 @@ description: "Quick set up guide to start sending notification on MS Teams chat 
   </Step>
   <Step title="Check logs to see the status of your sent notification">
     Once triggered, you can monitor the request and it's status on the '`Requests`' tab, and view step-by-step debugging of each execution on the '`Execution`' tab inside workflow.
+    
+    **Related API References:**
+    - [Trigger Workflow API](/reference/trigger-workflow-api) - Direct API trigger
+    - [Create/Update Users API](/reference/create-update-users) - User management
+    - [Trigger Event API](/reference/trigger-event) - Event-based triggers
   </Step>
   <Step title="Push to Production">
     In SuprSend, each environment is isolated, meaning workflows, users, and vendors are configured separately in testing and production workspaces.

--- a/docs/react-native-android-integration.mdx
+++ b/docs/react-native-android-integration.mdx
@@ -3,6 +3,8 @@ title: "Android Integration"
 description: "This document will cover integration steps for Android side of your ReactNative application."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 <Steps>

--- a/docs/react-native-ios-integration.mdx
+++ b/docs/react-native-ios-integration.mdx
@@ -3,6 +3,8 @@ title: "iOS Integration"
 description: "This document will cover integration steps for iOS side of your ReactNative application."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 <Steps>

--- a/docs/react-sdk.mdx
+++ b/docs/react-sdk.mdx
@@ -3,6 +3,8 @@ title: "SDK Integration"
 description: "SDK Integration to enable SuprSend features like Inbox, Preferences, and Webpush into React-based web applications."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 ## Installation
 
 We support 2 SDK's for react based applications.

--- a/docs/slack-quick-start.mdx
+++ b/docs/slack-quick-start.mdx
@@ -271,6 +271,11 @@ description: "Quick set up guide to start sending notification on Slack chat via
   </Step>
   <Step title="Check logs to see the status of your sent notification">
     Once triggered, you can monitor the request and it's status on the '`Requests`' tab, and view step-by-step debugging of each execution on the '`Execution`' tab inside workflow.
+    
+    **Related API References:**
+    - [Trigger Workflow API](/reference/trigger-workflow-api) - Direct API trigger
+    - [Create/Update Users API](/reference/create-update-users) - User management
+    - [Trigger Event API](/reference/trigger-event) - Event-based triggers
   </Step>
   <Step title="Push to Production">
     In SuprSend, each environment is isolated, meaning workflows, users, and vendors are configured separately in testing and production workspaces.

--- a/docs/sms-quick-start.mdx
+++ b/docs/sms-quick-start.mdx
@@ -264,6 +264,11 @@ description: "Set up guide to send SMS notifications via SuprSend."
 
   <Step title="Check logs to see the status of your sent notification">
     Once triggered, you can monitor the request and it's status on the "Requests" tab, and view step-by-step debugging of each execution on the "Execution" tab inside workflow.
+    
+    **Related API References:**
+    - [Trigger Workflow API](/reference/trigger-workflow-api) - Direct API trigger
+    - [Create/Update Users API](/reference/create-update-users) - User management
+    - [Trigger Event API](/reference/trigger-event) - Event-based triggers
   </Step>
 
   <Step title="Test with your SMS vendor">

--- a/docs/swift-integration.mdx
+++ b/docs/swift-integration.mdx
@@ -3,6 +3,8 @@ title: "Integration"
 description: "Integrate SuprSend SDK in your Swift project"
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 <Warning>
  **`SuprSendSdk` is deprecated. Please migrate to `SuprSend` SDK**
 

--- a/docs/web-components-integration.mdx
+++ b/docs/web-components-integration.mdx
@@ -3,6 +3,8 @@ title: "Integration"
 description: "How to integrate SuprSend inbox/feed components in Angular, Vue, VanillaJS, and other non-React frameworks."
 ---
 
+The SDK is a lightweight wrapper around our APIs. See full API Reference here → [API Reference](/reference/overview).
+
 <Warning>
   **End of Support for [@suprsend/web-inbox](https://github.com/suprsend/suprsend-web-inbox). Migrate to `@suprsend/web-components`**
 

--- a/docs/web-push-quick-start.mdx
+++ b/docs/web-push-quick-start.mdx
@@ -278,6 +278,11 @@ description: "Quick start guide to set up & send Web Push notifications using Su
   </Step>
   <Step title="Check logs to see the status of your sent notification">
     Once triggered, you can monitor the request and it's status on the '`Requests`' tab, and view step-by-step debugging of each execution on the '`Execution`' tab inside workflow.
+    
+    **Related API References:**
+    - [Trigger Workflow API](/reference/trigger-workflow-api) - Direct API trigger
+    - [Create/Update Users API](/reference/create-update-users) - User management
+    - [Trigger Event API](/reference/trigger-event) - Event-based triggers
   </Step>
   <Step title="Push to Production">
     In SuprSend, each environment is isolated, meaning workflows, users, and vendors are configured separately in testing and production workspaces.

--- a/docs/whatsapp-quick-start.mdx
+++ b/docs/whatsapp-quick-start.mdx
@@ -261,6 +261,11 @@ description: "Set up guide to send Whatsapp notifications via SuprSend."
 
   <Step title="Check logs to see the status of your sent notification" icon={5} stepNumber="5">
     Once triggered, you can monitor the request and it's status on the `Requests` tab, and view step-by-step debugging of each execution on the `Execution` tab inside workflow.
+    
+    **Related API References:**
+    - [Trigger Workflow API](/reference/trigger-workflow-api) - Direct API trigger
+    - [Create/Update Users API](/reference/create-update-users) - User management
+    - [Trigger Event API](/reference/trigger-event) - Event-based triggers
   </Step>
 
   <Step title="Test with your WhatsApp vendor" icon={6} stepNumber="6">


### PR DESCRIPTION
What:

- Added a standard line to SDK pages clarifying that SDKs are thin wrappers over our APIs, with a link to the top-level API Reference.
- Added a “Related API References” block in all channel Quickstart guides, linking to the most relevant endpoints: Trigger Workflow, Create/Update Users, and Trigger Event.

Why:

- Sets clear expectations about SDK scope and directs developers to full API details.
- Reduces friction by providing immediate, contextual API links from Quickstarts.
- Improves consistency and discoverability across the docs.

Scope:

- SDK integration pages updated:
```
Backend: docs/integrate-python-sdk.mdx, docs/integrate-node-sdk.mdx, docs/integrate-java-sdk.mdx, docs/integrate-go-sdk.mdx

Client: docs/integrate-javascript-sdk.mdx, docs/react-sdk.mdx, docs/integrate-android-sdk.mdx, docs/ios-integration.mdx, docs/swift-integration.mdx, docs/flutter-android-integration.mdx, docs/flutter-ios-integration.mdx, docs/react-native-android-integration.mdx, docs/react-native-ios-integration.mdx, docs/web-components-integration.mdx
```

- Quickstart pages updated:

`docs/email-quick-start.mdx, docs/sms-quick-start.mdx, docs/mobile-push-quick-start.mdx, docs/web-push-quick-start.mdx, docs/inbox-quick-start.mdx, docs/whatsapp-quick-start.mdx, docs/slack-quick-start.mdx, docs/ms-teams-quick-start.mdx`

Impact:

- Clearer SDK–API relationship
- Faster path to underlying APIs from Quickstarts
- More consistent developer experience across docs
