### PR TITLE
docs: document Expo SDK supported fields for Android/iOS push templates

### DIFF
--- a/docs/android-push-template.mdx
+++ b/docs/android-push-template.mdx
@@ -124,6 +124,12 @@ There will always be the case where you would be required to add dynamic content
   - Custom sound: Android native and React Native SDK version 2.2.0+
 </Note>
 
+<Note>
+  **Expo SDK support for advanced configurations**
+
+  From the table above, only **App Icon**, **Sound**, and **Custom Key-Value Pairs** are delivered through the [Expo SDK](/docs/expo-push-notifications). **Silent**, **Timeout**, **Sticky Notifications**, and **Notification Group** are not supported on Expo.
+</Note>
+
 ## Preview and test
 
 The right panel shows a live Android device preview, updated in real time as you edit. Variables render using data from the **Variables panel**.
@@ -195,6 +201,8 @@ Click **Commit** in the top bar to publish the current draft as a new live versi
     Use [Android Asset Studio](https://romannurik.github.io/AndroidAssetStudio/icons-notification.html) for quick icon generation. If you see the default bell icon, ensure all density sizes are present. If you see a solid square, the image lacks alpha transparency.
 
     **SDK requirement:** Android native and React Native SDK version 0.1.8+.
+
+    **Expo SDK:** App Icon is supported when delivering via the [Expo SDK](/docs/expo-push-notifications).
   </Accordion>
 
   <Accordion title="How do I add a custom notification sound?">
@@ -206,6 +214,8 @@ Click **Commit** in the top bar to publish the current draft as a new live versi
     - a user who uninstalled and reinstalled the app
 
     **SDK requirement:** Android native and React Native SDK version 2.2.0+.
+
+    **Expo SDK:** Sound is supported when delivering via the [Expo SDK](/docs/expo-push-notifications).
   </Accordion>
 
   <Accordion title="How does SuprSend optimise push notification images?">
@@ -216,6 +226,8 @@ Click **Commit** in the top bar to publish the current draft as a new live versi
 
   <Accordion title="What are silent notifications used for?">
     Silent notifications deliver a payload to the app without displaying anything to the user. Use them for background data sync, content pre-fetching, or triggering app-level logic. Combine with **Custom Key-Value Pairs** to pass structured data.
+
+    **Expo SDK:** Silent notifications are **not** supported when delivering via the [Expo SDK](/docs/expo-push-notifications).
   </Accordion>
 
   <Accordion title="What happens if a variable is missing at send time?">

--- a/docs/android-push-template.mdx
+++ b/docs/android-push-template.mdx
@@ -27,6 +27,23 @@ The Android Push editor is a form with title, message, image, action URL, and bu
 
 **Action Buttons** — *optional.* Up to 3 buttons with label + URL. Use 1-2 buttons with concise labels (2-3 words): "Track Order", "View Details". Supports Handlebars in both fields. Button colour is set in Organisation Settings.
 
+<Note>
+  **Expo SDK support**
+
+  When delivering Android Push via the [Expo SDK](/docs/expo-push-notifications), only the following fields are supported:
+
+  - Title
+  - Message (Body)
+  - Banner Image
+  - App Icon
+  - Sound
+  - Custom Key-Value Pairs
+
+  Action URL is **not** a supported field on Expo — pass the destination URL through a **Custom Key-Value Pair** and handle the tap in your app code.
+
+  Other fields listed on this page (Small Icon, Large Icon, Subtext, Action Buttons, Silent, Timeout, Sticky, Notification Group) are not delivered through the Expo SDK.
+</Note>
+
 ## Adding dynamic content in Android Push
 
 There will always be the case where you would be required to add dynamic content to a template, so as to personalise it for your users. To achieve this, you can add variables in the template, which will be replaced with the dynamic content at the time of sending push. To send actual values to replace variables at the time of communication trigger, use one of our frontend or backend SDKs. Here is a step-by-step guide:

--- a/docs/ios-push-template.mdx
+++ b/docs/ios-push-template.mdx
@@ -19,6 +19,12 @@ The iOS Push editor is a form with title, body, image, and action URL — with a
 
 **Action URL** — *optional.* URL opened on tap. Always set one — without it, tapping opens the app's default screen. Supports deep links and Handlebars variables.
 
+<Note>
+  **Expo SDK support**
+
+  When delivering iOS Push via the [Expo SDK](/docs/expo-push-notifications), all fields on this page are supported **except Image URL**. Rich notification images are not delivered through Expo.
+</Note>
+
 ## Adding dynamic content
 
 You can add variables in the template to personalise it for each recipient. Variables are replaced with actual data at send time.

--- a/docs/ios-push-template.mdx
+++ b/docs/ios-push-template.mdx
@@ -113,6 +113,8 @@ Click **Commit** in the top bar to publish the current draft as a new live versi
 <AccordionGroup>
   <Accordion title="Why aren't images showing in my push notification?">
     Your app needs a **Notification Service Extension** to display rich media (images, GIFs). The SuprSend iOS SDK includes this by default. If you're not using the SDK, add the extension manually. Supported formats: JPEG, PNG, GIF. Max size: 10 MB. Images display in the expanded notification view (long-press or swipe down). See [iOS SDK integration](/docs/ios-integration).
+
+    **Expo SDK:** Image URL is **not** supported when delivering via the [Expo SDK](/docs/expo-push-notifications) — images will not render on Expo apps.
   </Accordion>
 
   <Accordion title="How do deep links work in iOS push?">


### PR DESCRIPTION
Adds a callout on the Android Push and iOS Push template pages listing which template fields are actually delivered when using the Expo SDK, so users don't configure fields that won't render on Expo apps.

https://claude.ai/code/session_015cyFdizVZwuBaeFRbuhuwX