### PR TITLE
docs: Swift SDK 1.1.0 — CocoaPods git source, preferences args, chang…

### DIFF
--- a/changelog/overview.mdx
+++ b/changelog/overview.mdx
@@ -4,6 +4,18 @@ title: "Product Updates"
 mode: "wide"
 ---
 
+<Update label="25 May 2026">
+  ## Swift SDK — v1.1.0
+
+  [Swift SDK `1.1.0`](https://github.com/suprsend/suprsend-swift-sdk/releases/tag/1.1.0) ships with a preferences revamp and a couple of platform improvements.
+
+  - **Preferences revamp** → [`getPreferences`](/docs/ios-preferences#get-preferences-data) now accepts `locale`, `tags`, and `tenantId` for translated, tag-filtered, and tenant-level preference categories.
+  - **User-agent header updates** → Refined client identification on outbound requests.
+  - **Bundle ID tracking** → App bundle identifier is now captured alongside SDK events.
+
+  <Note>SuprSendSwift `1.1.0` and above are not published to the CocoaPods trunk. Install via the `:git` source — see [iOS Integration → CocoaPods](/docs/ios-integration#cocoapods).</Note>
+</Update>
+
 <Update label="13 May 2026">
   ## Python SDK — Messages API support
 

--- a/docs/developer/versioning/sdk-changelog.mdx
+++ b/docs/developer/versioning/sdk-changelog.mdx
@@ -2524,6 +2524,37 @@ The SuprSend SDK Changelog provides a comprehensive record of all SDK releases, 
         </div>
       </Accordion>
 
+      <Accordion title="Swift SDK - 1.1.0" icon="swift" iconType="brands">
+        <div className="mb-4">
+          <p><strong>Repository:</strong> <a href="https://github.com/suprsend/suprsend-swift-sdk">suprsend-swift-sdk</a></p>
+          <p><strong>Latest Release:</strong> <a href="https://github.com/suprsend/suprsend-swift-sdk/releases/tag/1.1.0">1.1.0</a></p>
+        </div>
+
+        <div className="space-y-6">
+          <div className="flex">
+            <div className="w-1 bg-green-500 mr-3 flex-shrink-0"></div>
+            <div className="flex-1">
+              <div className="flex items-center justify-between mb-1">
+                <h4 className="text-lg font-semibold">
+                  <a href="https://github.com/suprsend/suprsend-swift-sdk/releases/tag/1.1.0" className="text-blue-600 hover:underline">1.1.0</a>
+                </h4>
+                <span className="text-sm text-gray-500">May 25, 2026</span>
+              </div>
+              <div className="text-sm space-y-2">
+                <div>
+                  <p><strong>Changes:</strong></p>
+                  <ul className="ml-4 space-y-1">
+                    <li>Preferences revamp — added support for <code>locale</code>, <code>tags</code>, and tenant-level preferences in <code>getPreferences</code></li>
+                    <li>User-agent header updates</li>
+                    <li>Bundle ID tracking</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Accordion>
+
       <Accordion title="iOS SDK - 1.0.7" icon="apple" iconType="brands">
         <div className="mb-4">
           <p><strong>Repository:</strong> <a href="https://github.com/suprsend/SuprSend-iOS-SDK">SuprSend-iOS-SDK</a></p>

--- a/docs/ios-apns-push.mdx
+++ b/docs/ios-apns-push.mdx
@@ -156,12 +156,24 @@ func userNotificationCenter(
 
 </Accordion>
 <Accordion title="Cocoapods" defaultOpen={false}>
-  Add the SuprSendSwift SDK to your Podfile  as dependency to Notification Service Extension like below and then run `pod install`.
+  <Note>SuprSendSwift SDK versions `1.1.0` and above are not published to the CocoaPods trunk. Install them directly from the GitHub repository using the `:git` option as shown below.</Note>
+
+  **For SDK version `1.1.0` and above**, add the SDK to your Podfile as a dependency to the Notification Service Extension using the GitHub source and run `pod install`:
 
   <CodeGroup>
   ```ruby Podfile
   target '<your_notification_service_name>' do
-    pod "SuprSend"
+    pod 'SuprSendSwift', :git => 'https://github.com/suprsend/suprsend-swift-sdk.git', :tag => '1.1.0'
+  end
+  ```
+  </CodeGroup>
+
+  **For SDK versions below `1.1.0`**, add the SuprSendSwift SDK to your Podfile as a dependency to the Notification Service Extension like below and then run `pod install`:
+
+  <CodeGroup>
+  ```ruby Podfile
+  target '<your_notification_service_name>' do
+    pod "SuprSendSwift"
   end
   ```
   </CodeGroup>

--- a/docs/ios-integration.mdx
+++ b/docs/ios-integration.mdx
@@ -23,7 +23,17 @@ There are two ways you can install SuprSend SDK into your app:
 
 </Accordion>
 <Accordion title="Cocoapods" defaultOpen={false}>
-  Add the SuprSendSwift SDK to your Podfile as `pod "SuprSendSwift"` and run `pod install` to install the SDK.
+  <Note>SuprSendSwift SDK versions `1.1.0` and above are not published to the CocoaPods trunk. Install them directly from the GitHub repository using the `:git` option as shown below.</Note>
+
+  **For SDK version `1.1.0` and above**, add the SDK to your Podfile using the GitHub source and run `pod install`:
+
+  <CodeGroup>
+  ```ruby Podfile
+  pod 'SuprSendSwift', :git => 'https://github.com/suprsend/suprsend-swift-sdk.git', :tag => '1.1.0'
+  ```
+  </CodeGroup>
+
+  **For SDK versions below `1.1.0`**, add the SuprSendSwift SDK to your Podfile as `pod "SuprSendSwift"` and run `pod install` to install the SDK.
 </Accordion>
 
 ## Integration

--- a/docs/ios-preferences.mdx
+++ b/docs/ios-preferences.mdx
@@ -357,9 +357,15 @@ Use this method to get preferences data and create the preferences UI by followi
 
 <CodeGroup>
   ```swift syntax 
-  await SuprSend.shared.preferences.getPreferences(args: Preferences.Args(tenantId: "")) 
+  await SuprSend.shared.preferences.getPreferences(args: Preferences.Args(tenantId: "", tags: "", locale: "")) 
   ```
 </CodeGroup>
+
+| Argument (optional) | Description |
+| --------- | ----------- |
+| `tenantId` | Tenant identifier for loading per-tenant preferences |
+| `tags` | Filter categories by tags. Used to filter preference categories based on user's roles, department or teams. (see [Tags](/docs/notification-category#tags)) |
+| `locale` | Locale code (for example, `es`, `fr`, `de`, `es-AR`) to fetch preference translations in user's locale. When provided, category names and descriptions will be returned in the specified locale. If a translation is missing for the requested locale, the system automatically falls back in this order: `locale-region` (for example, `es-AR`) → `locale` (for example, `es`) → `en` (English - always available). |
 
 **Returns:** `async -> PreferenceAPIResponse`
 

--- a/docs/swift-apns-push.mdx
+++ b/docs/swift-apns-push.mdx
@@ -157,12 +157,24 @@ func userNotificationCenter(
 
 </Accordion>
 <Accordion title="Cocoapods" defaultOpen={false}>
-  Add the SuprSendSwift SDK to your Podfile  as dependency to Notification Service Extension like below and then run `pod install`.
+  <Note>SuprSendSwift SDK versions `1.1.0` and above are not published to the CocoaPods trunk. Install them directly from the GitHub repository using the `:git` option as shown below.</Note>
+
+  **For SDK version `1.1.0` and above**, add the SDK to your Podfile as a dependency to the Notification Service Extension using the GitHub source and run `pod install`:
 
   <CodeGroup>
   ```ruby Podfile
   target '<your_notification_service_name>' do
-    pod "SuprSend"
+    pod 'SuprSendSwift', :git => 'https://github.com/suprsend/suprsend-swift-sdk.git', :tag => '1.1.0'
+  end
+  ```
+  </CodeGroup>
+
+  **For SDK versions below `1.1.0`**, add the SuprSendSwift SDK to your Podfile as a dependency to the Notification Service Extension like below and then run `pod install`:
+
+  <CodeGroup>
+  ```ruby Podfile
+  target '<your_notification_service_name>' do
+    pod "SuprSendSwift"
   end
   ```
   </CodeGroup>

--- a/docs/swift-integration.mdx
+++ b/docs/swift-integration.mdx
@@ -24,7 +24,17 @@ There are two ways you can install SuprSend SDK into your app:
 
 </Accordion>
 <Accordion title="Cocoapods" defaultOpen={false}>
-  Add the SuprSendSwift SDK to your Podfile as `pod "SuprSend"` and run `pod install` to install the SDK.
+  <Note>SuprSendSwift SDK versions `1.1.0` and above are not published to the CocoaPods trunk. Install them directly from the GitHub repository using the `:git` option as shown below.</Note>
+
+  **For SDK version `1.1.0` and above**, add the SDK to your Podfile using the GitHub source and run `pod install`:
+
+  <CodeGroup>
+  ```ruby Podfile
+  pod 'SuprSendSwift', :git => 'https://github.com/suprsend/suprsend-swift-sdk.git', :tag => '1.1.0'
+  ```
+  </CodeGroup>
+
+  **For SDK versions below `1.1.0`**, add the SuprSendSwift SDK to your Podfile as `pod "SuprSendSwift"` and run `pod install` to install the SDK.
 </Accordion>
 
 ## Integration


### PR DESCRIPTION
…elog

- iOS/Swift integration & APNS push: document CocoaPods install via :git source for SuprSendSwift 1.1.0+ (trunk no longer supported); preserve pre-1.1.0 instructions for older installs.
- iOS preferences: document tenantId, tags, and locale args on getPreferences (parity with js-preferences).
- SDK changelog: add Swift SDK 1.1.0 accordion (preferences revamp, user-agent updates, bundle id tracking).
- Product updates: add 25 May 2026 entry for Swift SDK 1.1.0.